### PR TITLE
On Angular 5 build importing from rxjs without providing the required…

### DIFF
--- a/src/GoogleApiService.ts
+++ b/src/GoogleApiService.ts
@@ -1,4 +1,4 @@
-import {Observable} from "rxjs";
+import {Observable} from "rxjs/Observable";
 import {Inject, Injectable, InjectionToken} from "@angular/core";
 import {GoogleApiConfig, NgGapiClientConfig} from "./config/GoogleApiConfig";
 import {Observer} from "rxjs/Observer";

--- a/src/GoogleAuthService.ts
+++ b/src/GoogleAuthService.ts
@@ -1,5 +1,5 @@
 import {Injectable} from "@angular/core";
-import {Observable} from "rxjs";
+import {Observable} from "rxjs/Observable";
 
 import {Observer} from "rxjs/Observer";
 import {GoogleApiService} from "./GoogleApiService";


### PR DESCRIPTION
… resource breaks the build as described on https://github.com/angular/angular/issues/20095