### PR TITLE
Changing auth to be fulfilled through a promise to handle race condit…

### DIFF
--- a/src/GoogleAuthService.ts
+++ b/src/GoogleAuthService.ts
@@ -25,10 +25,11 @@ export class GoogleAuthService {
     private loadGapiAuth(): Observable<GoogleAuth> {
         return Observable.create((observer: Observer<GoogleAuth>) => {
             gapi.load('auth2', () => {
-                let auth = gapi.auth2.init(this.googleApi.getConfig().getClientConfig());
-                this.GoogleAuth = auth;
-                observer.next(auth);
-                observer.complete();
+                gapi.auth2.init(this.googleApi.getConfig().getClientConfig()).then((auth: GoogleAuth) => {
+                  this.GoogleAuth = auth;
+                  observer.next(auth);
+                  observer.complete();
+                });
             });
         });
     }


### PR DESCRIPTION
Changing auth to be fulfilled through a promise to handle race condition on redirect logins.

Mentioned here: [reference](https://developers.google.com/identity/sign-in/web/reference)
- Use the then() method to get a Promise that is resolved when the gapi.auth2.GoogleAuth object finishes initializing.

Still works for both popup and now works in cases of redirect.


