### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -80,6 +80,15 @@ interface ClientConfig {
 
 ##### Example:
 ```typescript
+import {
+    GoogleApiModule, 
+    GoogleApiService, 
+    GoogleAuthService, 
+    NgGapiClientConfig, 
+    NG_GAPI_CONFIG,
+    GoogleApiConfig
+} from "ng-gapi";
+
 let gapiClientConfig: NgGapiClientConfig = {
     client_id: "CLIENT_ID",
     discoveryDocs: ["https://analyticsreporting.googleapis.com/$discovery/rest?version=v4"],


### PR DESCRIPTION
it would be nice to have the import statement in the README tutorial, i'm new to angular, so i'm not sure this is correct convention...

import {
    GoogleApiModule, 
    GoogleApiService, 
    GoogleAuthService, 
    NgGapiClientConfig, 
    NG_GAPI_CONFIG,
    GoogleApiConfig
} from "ng-gapi";

Also, if you're going to add the imports, the GoogleUser needs to be imported or referenced directly when creating the injectable.

... it would just be nice to have all the code there and not just the class blocks, you know?