### PR TITLE
change way of using "of" in GoogleAuthService for RxJs 5.5 capability

### DIFF
--- a/src/GoogleAuthService.ts
+++ b/src/GoogleAuthService.ts
@@ -1,8 +1,8 @@
 import {Injectable} from "@angular/core";
 import {Observable} from "rxjs/Observable";
 import {Observer} from "rxjs/Observer";
-import 'rxjs/add/observable/of';
-import { mergeMap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import{ mergeMap } from 'rxjs/operators';
 import {GoogleApiService} from "./GoogleApiService";
 import GoogleAuth = gapi.auth2.GoogleAuth;
 
@@ -20,7 +20,7 @@ export class GoogleAuthService {
         if (!this.GoogleAuth) {
             return this.googleApi.onLoad().pipe(mergeMap(() => { return _this.loadGapiAuth(); }));
         }
-        return Observable.of(this.GoogleAuth);
+        return of(this.GoogleAuth);
     }
 
     private loadGapiAuth(): Observable<GoogleAuth> {


### PR DESCRIPTION
Update the way of using `of `in `GoogleAuthService `for `RxJs 5.5` capability