### PR TITLE
Optional new GoogleAuth instance creation, to load new configuration

### DIFF
--- a/src/GoogleAuthService.ts
+++ b/src/GoogleAuthService.ts
@@ -16,8 +16,8 @@ export class GoogleAuthService {
         });
     }
 
-    public getAuth(): Observable<GoogleAuth> {
-        if (!this.GoogleAuth) {
+    public getAuth(newInstance = false): Observable<GoogleAuth> {
+        if (!this.GoogleAuth || newInstance) {
             return this.googleApi.onLoad()
                 .pipe(mergeMap(() => this.loadGapiAuth()));
         }


### PR DESCRIPTION
This is useful when I set multiples json credentials (with client id) in the app. If not, the module has loaded always the same client id in the app, unless you reload the page