### PR TITLE
Feature/ng packagr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /lib
+/dist
 /node_modules
 /bower_components
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "url": "git+https://github.com/rubenCodeforges/ng-gapi"
   },
   "keywords": [
+    "Angular2",
+    "Angular4",
+    "Angular5",
+    "Angular6",
+    "Angular7",
+    "Angular8",
     "Angular9",
     "Angular",
     "GoogleApi",
@@ -30,6 +36,12 @@
     "google",
     "api",
     "angular",
+    "2",
+    "4",
+    "5",
+    "ng2",
+    "ng4",
+    "ng5",
     "gapi",
     "ng-gapi"
   ],

--- a/package.json
+++ b/package.json
@@ -1,14 +1,20 @@
 {
+  "$schema": "./node_modules/ng-packagr/package.schema.json",
   "name": "ng-gapi",
   "version": "0.0.93",
   "description": "Angular 9+ Google api module ng-gapi",
-  "main": "./lib/index.js",
-  "files": [
-    "lib/*"
-  ],
-  "typings": "./lib/index.d.ts",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "src/index.ts"
+    },
+    "whitelistedNonPeerDependencies": [
+      "@types/gapi",
+      "@types/gapi.auth2",
+      "tslib"
+    ]
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "ng-packagr -p package.json",
     "tsc": "ngc"
   },
   "repository": {
@@ -16,12 +22,6 @@
     "url": "git+https://github.com/rubenCodeforges/ng-gapi"
   },
   "keywords": [
-    "Angular2",
-    "Angular4",
-    "Angular5",
-    "Angular6",
-    "Angular7",
-    "Angular8",
     "Angular9",
     "Angular",
     "GoogleApi",
@@ -30,12 +30,6 @@
     "google",
     "api",
     "angular",
-    "2",
-    "4",
-    "5",
-    "ng2",
-    "ng4",
-    "ng5",
     "gapi",
     "ng-gapi"
   ],
@@ -51,16 +45,17 @@
     "tslib": "^1.11.1"
   },
   "devDependencies": {
+    "@angular/animations": "^9.1.0",
+    "@angular/common": "^9.1.0",
     "@angular/compiler": "^9.1.0",
     "@angular/compiler-cli": "^9.1.0",
     "@angular/core": "^9.1.0",
     "@angular/platform-server": "^9.1.0",
-    "@angular/animations": "^9.1.0",
-    "@angular/common": "^9.1.0",
     "@types/node": "^13.9.8",
+    "ng-packagr": "^10.1.0",
     "rxjs": "^6.5.4",
-    "typescript": "^3.8.3",
     "tslint": "~6.1.0",
+    "typescript": "~3.8.3",
     "zone.js": "^0.10.3"
   }
 }

--- a/src/GoogleAuthService.ts
+++ b/src/GoogleAuthService.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {Injectable, Inject} from '@angular/core';
 import {GoogleApiService} from './GoogleApiService';
 import GoogleAuth = gapi.auth2.GoogleAuth;
 import {Observable, Observer, of} from 'rxjs';
@@ -8,7 +8,7 @@ import {mergeMap} from 'rxjs/operators';
 export class GoogleAuthService {
   private GoogleAuth: GoogleAuth = undefined;
 
-  constructor(private googleApi: GoogleApiService) {
+  constructor(@Inject(GoogleApiService) private googleApi: GoogleApiService) {
     this.googleApi.onLoad().subscribe(() => {
       this.loadGapiAuth().subscribe();
     });


### PR DESCRIPTION
Introduce ng packagr for building library. 

Solves #96 and #103.

To deploy library, you have to use `npm publish dist` according to document (or maybe `npm publish` inside dist directory).
